### PR TITLE
Update third-party docs: webpack

### DIFF
--- a/dist/advanced/third-party.html
+++ b/dist/advanced/third-party.html
@@ -100,21 +100,57 @@
 <blockquote>
 <p>Including third-party dependencies in your toolkit</p>
 </blockquote>
-<p>Many times you'll want to include a third-party library like <a href="http://jquery.com">jQuery</a> in your toolkit. It's fairly easy to do so, but requires some modification to the <code>gulpfile.js</code>.</p>
-<h2>Using Bower for dependency management</h2>
-<p><a href="http://bower.io">Bower</a> is a great tool for managing third party client side dependencies. Here's how to leverage Bower on a Fabricator instance:</p>
+<p>Fabricator makes it easy to include a third-party library like <a href="http://jquery.com">jQuery</a>
+in your toolkit.</p>
+<h2>Using Webpack to bundle dependencies</h2>
+<p>Fabricator uses <a href="webpack.github.io">Webpack</a> to bundle modules using the
+<a href="http://webpack.github.io/docs/commonjs.html">CommonJS</a> module syntax:</p>
+<pre><code class="language-javascript">/* src/assets/toolkit/scripts/my-module.js */
+module.exports = {
+  foo: function() {
+    return 'bar';
+  }
+};
+</code></pre>
+<pre><code class="language-javascript">/* src/assets/toolkit/scripts/toolkit.js */
+var myModule = require('./my-module');
+myModule.foo(); // 'bar'
+</code></pre>
+<p>In the above example, webpack will find all the dependencies and
+output a single file that contains both <code>my-module.js</code> and <code>toolkit.js</code>.</p>
+<h2>Dependency Management</h2>
+<p>It's recommended that you leverage either <a href="https://www.npmjs.com/">NPM</a> or <a href="http://bower.io/search/">Bower</a> to manage dependencies.</p>
+<h3>Option 1: NPM</h3>
+<p><a href="http://npmjs.com">NPM</a> is the recommended way to add third-party dependencies.</p>
+<pre><code class="language-bash">$ npm install --save-dev jquery
+</code></pre>
+<h4>Including NPM dependencies</h4>
+<p>By default, if a <code>require()</code> call is not prefixed with a path, webpack will
+recursively search the <code>node_modules</code> directories for the specified module.</p>
+<pre><code class="language-javascript">// &quot;./&quot; tells webpack to search the current
+// directory for &quot;my-module&quot;
+var myModule = require('./my-module');
+
+// no path was specified, so recursively search
+// &quot;node_modules&quot; directories for &quot;jquery&quot;
+var $ = require('jquery');
+$('#my-button').hide();
+</code></pre>
+<h3>Option 2: Bower</h3>
+<p><a href="http://bower.io">Bower</a> is a great tool for managing third party client side
+dependencies. Here's how to leverage Bower on a Fabricator instance:</p>
 <ol>
 <li>Install Bower globally for access to the CLI <code>$ npm install -g bower</code></li>
 <li>Install Bower local to project <code>$ npm install bower --save-dev</code></li>
 <li>Run <code>$ bower init</code> to initialize Bower for your project.</li>
-<li>Add a <code>.bowerrc</code> config file to your project root. The <code>&quot;directory&quot;</code> property defines where dependencies are installed.</li>
+<li>Add a <code>.bowerrc</code> config file to your project root.</li>
 </ol>
 <p><strong>.bowerrc</strong></p>
 <pre><code class="language-javascript">{
   &quot;directory&quot;: &quot;bower_components&quot;
 }
 </code></pre>
-<ol start="4">
+<ol start="5">
 <li>Update <code>package.json</code> <code>scripts</code> object to hook into Bower install task.</li>
 </ol>
 <p><strong>package.json</strong></p>
@@ -128,7 +164,7 @@
   &quot;test&quot;: &quot;npm run build&quot;
 },
 </code></pre>
-<ol start="5">
+<ol start="6">
 <li>
 <p>Add <code>bower_components</code> to <code>.gitignore</code>.</p>
 </li>
@@ -138,48 +174,53 @@
 </ol>
 <pre><code class="language-bash">$ bower install --save-dev jquery
 </code></pre>
-<h2>Including vendor scripts</h2>
-<p>Fabricator gives you a couple of options for building vendor files.</p>
-<h3>Option 1: Include vendor files directly in toolkit.js</h3>
-<p><em>This is the more portable option - it will produce a single <code>.js</code> file.</em></p>
-<p>Since Fabricator uses <a href="http://webpack.github.io/">webpack</a> for bundling, you have the option to include non-CommonJS scripts by using the <code>script!</code> <a href="https://github.com/webpack/script-loader">loader shim</a>.</p>
-<pre><code class="language-javascript">// vendor files
-require('script!../../../../bower_components/path/to/file1');
-require('script!../../../../bower_components/path/to/file2');
-
-// rest of the toolkit.js
-...
-</code></pre>
-<p>This will load the target files as if it were a normal concatenation.</p>
-<p>If a file is written as CommonJS, you can treat it as a module:</p>
-<pre><code class="language-javascript">// with bower
-var $ = require('../../../../bower_components/jquery/dist/jquery');
-
-// or with npm
-var $ = require('jquery');
-</code></pre>
-<h3>Option 2: Produce a separate vendor.js file</h3>
-<p><em>Use this option if you want to keep separate <code>toolkit.js</code> and <code>vendor.js</code> files.</em></p>
-<p>Create a <code>vendor</code> property to the <code>config</code> object in <code>gulpfile.js</code> Add target files as an array:</p>
-<pre><code class="language-javascript">var config = {
-    ...
-    src: {
-        scripts: {
-            fabricator: [
-                ...
-            ],
-            vendor: [
-                'bower_components/jquery/dist/jquery',
-                'bower_components/some-jquery-plugin/plugin'
-            ],
-            toolkit: './src/assets/toolkit/scripts/toolkit.js'
-        },
-        ...
-    },
-    ...
+<h4>Including Bower dependencies</h4>
+<ol>
+<li>Tell webpack to search &quot;bower_components&quot;</li>
+</ol>
+<p><strong>webpack.config.js</strong></p>
+<pre><code class="language-javascript">// add the &quot;resolve&quot; property to the config
+var config = {
+  /* other config properties */
+  resolve: {
+    modulesDirectories: ['node_modules', 'bower_components']
+  }
 };
 </code></pre>
-<p>The <code>webpack.config.js</code> file is already setup to read a <code>config.src.vendor</code> array if it exists and will output a <code>vendor.js</code> file.</p>
+<ol start="2">
+<li>Require the module</li>
+</ol>
+<p>Unlike including NPM dependencies, Bower has no rules for how a module
+is structured. As a result, you will often have to specify a more specific path:</p>
+<pre><code class="language-javascript">var myLibrary = require('myLibrary/dist/library');
+</code></pre>
+<h2>Handling modules that do not use CommonJS</h2>
+<p>Many Bower modules are just plain JavaScript files that don't use the CommonJS
+module syntax â€” an example might be a jQuery plugin.</p>
+<p>Fabricator includes both the <a href="https://github.com/webpack/imports-loader">Imports Loader</a>
+and the <a href="https://github.com/webpack/script-loader">Script Loader</a> to handle these cases.</p>
+<h3>Imports Loader</h3>
+<pre><code class="language-javascript">// installed via NPM
+var $ = require('jquery');
+
+// installed via Bower
+require('imports?$=jquery!somePlugin/dist/plugin');
+
+$('#my-button').somePlugin();
+</code></pre>
+<h3>Script Loader</h3>
+<blockquote>
+<p>This loader evaluates code in the global context, just like you would add
+the code into a script tag. In this mode every normal library should work.
+require, module, etc. are undefined.</p>
+</blockquote>
+<blockquote>
+<p>Note: The file is added as string to the bundle. It is not minimized by webpack,
+so use a minimized version. There is also no dev tool support for
+libraries added by this loader.</p>
+</blockquote>
+<pre><code class="language-javascript">require('script!anotherLib/lib/another-lib');
+</code></pre>
 
 		</div>
 	</div>

--- a/dist/advanced/third-party.html
+++ b/dist/advanced/third-party.html
@@ -107,7 +107,7 @@
 <li>Install Bower globally for access to the CLI <code>$ npm install -g bower</code></li>
 <li>Install Bower local to project <code>$ npm install bower --save-dev</code></li>
 <li>Run <code>$ bower init</code> to initialize Bower for your project.</li>
-<li>Add a <code>.bowerrc</code> config file to your project root.</li>
+<li>Add a <code>.bowerrc</code> config file to your project root. The <code>&quot;directory&quot;</code> property defines where dependencies are installed.</li>
 </ol>
 <p><strong>.bowerrc</strong></p>
 <pre><code class="language-javascript">{
@@ -139,66 +139,47 @@
 <pre><code class="language-bash">$ bower install --save-dev jquery
 </code></pre>
 <h2>Including vendor scripts</h2>
-<ol>
-<li>Install the <a href="https://www.npmjs.com/package/streamqueue">streamqueue</a> package:</li>
-</ol>
-<pre><code class="language-bash">$ npm install --save-dev streamqueue
-</code></pre>
-<ol start="2">
-<li>Create a <code>config.src.vendor</code> array and include vendor file paths.</li>
-<li>Update the <code>scripts:toolkit</code> task to include vendor files. Break the <code>scripts:toolkit</code> task into two streams - <code>toolkit()</code> and <code>vendor()</code> - then merge streams using <code>streamqueue()</code>.</li>
-</ol>
-<pre><code class="language-javascript">var browserify = require('browserify');
-var concat = require('gulp-concat');
-var gulp = require('gulp');
-var gulpif = require('gulp-if');
-var gutil = require('gulp-util');
-var source = require('vinyl-source-stream');
-var streamqueue = require('streamqueue');
-var streamify = require('gulp-streamify');
-var uglify = require('gulp-uglify');
+<p>Fabricator gives you a couple of options for building vendor files.</p>
+<h3>Option 1: Include vendor files directly in toolkit.js</h3>
+<p><em>This is the more portable option - it will produce a single <code>.js</code> file.</em></p>
+<p>Since Fabricator uses <a href="http://webpack.github.io/">webpack</a> for bundling, you have the option to include non-CommonJS scripts by using the <code>script!</code> <a href="https://github.com/webpack/script-loader">loader shim</a>.</p>
+<pre><code class="language-javascript">// vendor files
+require('script!../../../../bower_components/path/to/file1');
+require('script!../../../../bower_components/path/to/file2');
 
-var config = {
-    dev: gutil.env.dev,
+// rest of the toolkit.js
+...
+</code></pre>
+<p>This will load the target files as if it were a normal concatenation.</p>
+<p>If a file is written as CommonJS, you can treat it as a module:</p>
+<pre><code class="language-javascript">// with bower
+var $ = require('../../../../bower_components/jquery/dist/jquery');
+
+// or with npm
+var $ = require('jquery');
+</code></pre>
+<h3>Option 2: Produce a separate vendor.js file</h3>
+<p><em>Use this option if you want to keep separate <code>toolkit.js</code> and <code>vendor.js</code> files.</em></p>
+<p>Create a <code>vendor</code> property to the <code>config</code> object in <code>gulpfile.js</code> Add target files as an array:</p>
+<pre><code class="language-javascript">var config = {
+    ...
     src: {
         scripts: {
             fabricator: [
-                'src/fabricator/scripts/prism.js',
-                'src/fabricator/scripts/fabricator.js'
+                ...
             ],
             vendor: [
-                'bower_components/jquery/dist/jquery.js'
+                'bower_components/jquery/dist/jquery',
+                'bower_components/some-jquery-plugin/plugin'
             ],
-            toolkit: './src/toolkit/assets/scripts/toolkit.js'
-        }
+            toolkit: './src/assets/toolkit/scripts/toolkit.js'
+        },
+        ...
     },
-    dest: 'dist'
+    ...
 };
-
-gulp.task('scripts:toolkit', function () {
-
-    var toolkit = function () {
-        return browserify(config.src.scripts.toolkit).bundle()
-            .on('error', function (error) {
-                gutil.log(gutil.colors.red(error));
-                this.emit('end');
-            })
-            .pipe(source('toolkit.js'));
-    };
-
-    var vendor = function () {
-        return gulp.src(config.src.scripts.vendor)
-            .pipe(concat('vendor.js'));
-    };
-
-    return streamqueue({ objectMode: true }, vendor(), toolkit())
-        .pipe(streamify(concat('toolkit.js')))
-        .pipe(gulpif(!config.dev, streamify(uglify())))
-        .pipe(gulp.dest(config.dest + '/assets/toolkit/scripts'));
-
-});
-
 </code></pre>
+<p>The <code>webpack.config.js</code> file is already setup to read a <code>config.src.vendor</code> array if it exists and will output a <code>vendor.js</code> file.</p>
 
 		</div>
 	</div>

--- a/src/views/docs/advanced/third-party.html
+++ b/src/views/docs/advanced/third-party.html
@@ -19,7 +19,7 @@ Many times you'll want to include a third-party library like [jQuery](http://jqu
 0. Install Bower globally for access to the CLI `$ npm install -g bower`
 1. Install Bower local to project `$ npm install bower --save-dev`
 2. Run `$ bower init` to initialize Bower for your project.
-3. Add a `.bowerrc` config file to your project root.
+3. Add a `.bowerrc` config file to your project root. The `"directory"` property defines where dependencies are installed.
 
 **.bowerrc**
 
@@ -55,66 +55,61 @@ $ bower install --save-dev jquery
 
 ## Including vendor scripts
 
-1. Install the [streamqueue](https://www.npmjs.com/package/streamqueue) package:
+Fabricator gives you a couple of options for building vendor files.
 
-```bash
-$ npm install --save-dev streamqueue
-```
+### Option 1: Include vendor files directly in toolkit.js
 
-2. Create a `config.src.vendor` array and include vendor file paths.
-3. Update the `scripts:toolkit` task to include vendor files. Break the `scripts:toolkit` task into two streams - `toolkit()` and `vendor()` - then merge streams using `streamqueue()`.
+*This is the more portable option - it will produce a single `.js` file.*
+
+Since Fabricator uses [webpack](http://webpack.github.io/) for bundling, you have the option to include non-CommonJS scripts by using the `script!` [loader shim](https://github.com/webpack/script-loader).
 
 ```javascript
-var browserify = require('browserify');
-var concat = require('gulp-concat');
-var gulp = require('gulp');
-var gulpif = require('gulp-if');
-var gutil = require('gulp-util');
-var source = require('vinyl-source-stream');
-var streamqueue = require('streamqueue');
-var streamify = require('gulp-streamify');
-var uglify = require('gulp-uglify');
+// vendor files
+require('script!../../../../bower_components/path/to/file1');
+require('script!../../../../bower_components/path/to/file2');
 
+// rest of the toolkit.js
+...
+```
+
+This will load the target files as if it were a normal concatenation.
+
+If a file is written as CommonJS, you can treat it as a module:
+
+```javascript
+// with bower
+var $ = require('../../../../bower_components/jquery/dist/jquery');
+
+// or with npm
+var $ = require('jquery');
+```
+
+### Option 2: Produce a separate vendor.js file
+
+*Use this option if you want to keep separate `toolkit.js` and `vendor.js` files.*
+
+Create a `vendor` property to the `config` object in `gulpfile.js` Add target files as an array:
+
+```javascript
 var config = {
-	dev: gutil.env.dev,
+	...
 	src: {
 		scripts: {
 			fabricator: [
-				'src/fabricator/scripts/prism.js',
-				'src/fabricator/scripts/fabricator.js'
+				...
 			],
 			vendor: [
-				'bower_components/jquery/dist/jquery.js'
+				'bower_components/jquery/dist/jquery',
+				'bower_components/some-jquery-plugin/plugin'
 			],
-			toolkit: './src/toolkit/assets/scripts/toolkit.js'
-		}
+			toolkit: './src/assets/toolkit/scripts/toolkit.js'
+		},
+		...
 	},
-	dest: 'dist'
+	...
 };
-
-gulp.task('scripts:toolkit', function () {
-
-	var toolkit = function () {
-		return browserify(config.src.scripts.toolkit).bundle()
-			.on('error', function (error) {
-				gutil.log(gutil.colors.red(error));
-				this.emit('end');
-			})
-			.pipe(source('toolkit.js'));
-	};
-
-	var vendor = function () {
-		return gulp.src(config.src.scripts.vendor)
-			.pipe(concat('vendor.js'));
-	};
-
-	return streamqueue({ objectMode: true }, vendor(), toolkit())
-		.pipe(streamify(concat('toolkit.js')))
-		.pipe(gulpif(!config.dev, streamify(uglify())))
-		.pipe(gulp.dest(config.dest + '/assets/toolkit/scripts'));
-
-});
-
 ```
+
+The `webpack.config.js` file is already setup to read a `config.src.vendor` array if it exists and will output a `vendor.js` file.
 
 {{/markdown}}

--- a/src/views/docs/advanced/third-party.html
+++ b/src/views/docs/advanced/third-party.html
@@ -10,16 +10,69 @@ section: Documentation
 
 > Including third-party dependencies in your toolkit
 
-Many times you'll want to include a third-party library like [jQuery](http://jquery.com) in your toolkit. It's fairly easy to do so, but requires some modification to the `gulpfile.js`.
+Fabricator makes it easy to include a third-party library like [jQuery](http://jquery.com)
+in your toolkit.
 
-## Using Bower for dependency management
+## Using Webpack to bundle dependencies
 
-[Bower](http://bower.io) is a great tool for managing third party client side dependencies. Here's how to leverage Bower on a Fabricator instance:
+Fabricator uses [Webpack](webpack.github.io) to bundle modules using the
+[CommonJS](http://webpack.github.io/docs/commonjs.html) module syntax:
 
-0. Install Bower globally for access to the CLI `$ npm install -g bower`
-1. Install Bower local to project `$ npm install bower --save-dev`
-2. Run `$ bower init` to initialize Bower for your project.
-3. Add a `.bowerrc` config file to your project root. The `"directory"` property defines where dependencies are installed.
+```javascript
+/* src/assets/toolkit/scripts/my-module.js */
+module.exports = {
+  foo: function() {
+    return 'bar';
+  }
+};
+````
+
+```javascript
+/* src/assets/toolkit/scripts/toolkit.js */
+var myModule = require('./my-module');
+myModule.foo(); // 'bar'
+```
+
+In the above example, webpack will find all the dependencies and
+output a single file that contains both `my-module.js` and `toolkit.js`.
+
+## Dependency Management
+
+It's recommended that you leverage either [NPM](https://www.npmjs.com/) or [Bower](http://bower.io/search/) to manage dependencies.
+
+### Option 1: NPM
+
+[NPM](http://npmjs.com) is the recommended way to add third-party dependencies.
+
+```bash
+$ npm install --save-dev jquery
+```
+
+#### Including NPM dependencies
+
+By default, if a `require()` call is not prefixed with a path, webpack will
+recursively search the `node_modules` directories for the specified module.
+
+```javascript
+// "./" tells webpack to search the current
+// directory for "my-module"
+var myModule = require('./my-module');
+
+// no path was specified, so recursively search
+// "node_modules" directories for "jquery"
+var $ = require('jquery');
+$('#my-button').hide();
+```
+
+### Option 2: Bower
+
+[Bower](http://bower.io) is a great tool for managing third party client side
+dependencies. Here's how to leverage Bower on a Fabricator instance:
+
+1. Install Bower globally for access to the CLI `$ npm install -g bower`
+2. Install Bower local to project `$ npm install bower --save-dev`
+3. Run `$ bower init` to initialize Bower for your project.
+4. Add a `.bowerrc` config file to your project root.
 
 **.bowerrc**
 
@@ -29,7 +82,7 @@ Many times you'll want to include a third-party library like [jQuery](http://jqu
 }
 ```
 
-4. Update `package.json` `scripts` object to hook into Bower install task.
+5. Update `package.json` `scripts` object to hook into Bower install task.
 
 **package.json**
 
@@ -45,71 +98,72 @@ Many times you'll want to include a third-party library like [jQuery](http://jqu
 },
 ```
 
-5. Add `bower_components` to `.gitignore`.
+6. Add `bower_components` to `.gitignore`.
 
-6. Install dependencies with Bower.
+7. Install dependencies with Bower.
 
 ```bash
 $ bower install --save-dev jquery
 ```
 
-## Including vendor scripts
 
-Fabricator gives you a couple of options for building vendor files.
+#### Including Bower dependencies
 
-### Option 1: Include vendor files directly in toolkit.js
+1. Tell webpack to search "bower_components"
 
-*This is the more portable option - it will produce a single `.js` file.*
-
-Since Fabricator uses [webpack](http://webpack.github.io/) for bundling, you have the option to include non-CommonJS scripts by using the `script!` [loader shim](https://github.com/webpack/script-loader).
+**webpack.config.js**
 
 ```javascript
-// vendor files
-require('script!../../../../bower_components/path/to/file1');
-require('script!../../../../bower_components/path/to/file2');
-
-// rest of the toolkit.js
-...
-```
-
-This will load the target files as if it were a normal concatenation.
-
-If a file is written as CommonJS, you can treat it as a module:
-
-```javascript
-// with bower
-var $ = require('../../../../bower_components/jquery/dist/jquery');
-
-// or with npm
-var $ = require('jquery');
-```
-
-### Option 2: Produce a separate vendor.js file
-
-*Use this option if you want to keep separate `toolkit.js` and `vendor.js` files.*
-
-Create a `vendor` property to the `config` object in `gulpfile.js` Add target files as an array:
-
-```javascript
+// add the "resolve" property to the config
 var config = {
-	...
-	src: {
-		scripts: {
-			fabricator: [
-				...
-			],
-			vendor: [
-				'bower_components/jquery/dist/jquery',
-				'bower_components/some-jquery-plugin/plugin'
-			],
-			toolkit: './src/assets/toolkit/scripts/toolkit.js'
-		},
-		...
-	},
-	...
+  /* other config properties */
+  resolve: {
+    modulesDirectories: ['node_modules', 'bower_components']
+  }
 };
 ```
 
-The `webpack.config.js` file is already setup to read a `config.src.vendor` array if it exists and will output a `vendor.js` file.
+2. Require the module
+
+Unlike including NPM dependencies, Bower has no rules for how a module
+is structured. As a result, you will often have to specify a more specific path:
+
+```javascript
+var myLibrary = require('myLibrary/dist/library');
+```
+
+## Handling modules that do not use CommonJS
+
+Many Bower modules are just plain JavaScript files that don't use the CommonJS
+module syntax â€” an example might be a jQuery plugin.
+
+Fabricator includes both the [Imports Loader](https://github.com/webpack/imports-loader)
+and the [Script Loader](https://github.com/webpack/script-loader) to handle these cases.
+
+### Imports Loader
+
+```javascript
+// installed via NPM
+var $ = require('jquery');
+
+// installed via Bower
+require('imports?$=jquery!somePlugin/dist/plugin');
+
+$('#my-button').somePlugin();
+```
+
+### Script Loader
+
+> This loader evaluates code in the global context, just like you would add
+the code into a script tag. In this mode every normal library should work.
+require, module, etc. are undefined.
+
+> Note: The file is added as string to the bundle. It is not minimized by webpack,
+so use a minimized version. There is also no dev tool support for
+libraries added by this loader.
+
+```javascript
+require('script!anotherLib/lib/another-lib');
+```
 
 {{/markdown}}


### PR DESCRIPTION
Update the recommendations on third part integrations since Fabricator now uses webpack.
