### PR TITLE
Adding missing word to the last section of documentation.

### DIFF
--- a/src/views/docs/building-a-toolkit/materials.html
+++ b/src/views/docs/building-a-toolkit/materials.html
@@ -105,7 +105,7 @@ Number prefixes are ignored in partial keywords, so in the example above, the ma
 {{> bar}}{{{{/raw}}}}
 ```
 
-Ordering works with any quantity of dot-delimited number prefixes. You can pretty granular:
+Ordering works with any quantity of dot-delimited number prefixes. You can get pretty granular:
 
 ```
 01.00-foo.html


### PR DESCRIPTION
It seems that the word _get_ was missing from the last section of _building-a-toolkit/materials_.

**Changed**

> Ordering works with any quantity of dot-delimited number prefixes. You can pretty granular:
> 
> ```
> 01.00-foo.html
> 01.01-bar.html
> ```

**To**

> Ordering works with any quantity of dot-delimited number prefixes. You can get pretty granular:
> 
> ```
> 01.00-foo.html
> 01.01-bar.html
> ```
