### PR TITLE
Fixing small typo on data page

### DIFF
--- a/src/views/docs/building-a-toolkit/data.html
+++ b/src/views/docs/building-a-toolkit/data.html
@@ -14,7 +14,7 @@ Sometimes it is helpful to decouple page data from materials and layouts.
 
 ## src/data
 
-Data can be store in JSON or YML files in the `src/data` directory.
+Data can be stored in JSON or YML files in the `src/data` directory.
 
 Data within these files is accessed using dot notation. For example, given `home.yml`:
 


### PR DESCRIPTION
Made change to typo in _src/data_ 

**Changed**

> Data can be store in JSON or YML files in the src/data directory.

**To**

> Data can be stored in JSON or YML files in the src/data directory.
