### PR TITLE
Correcting typo on on building-a-toolkit/assets

### DIFF
--- a/src/views/docs/building-a-toolkit/assets.html
+++ b/src/views/docs/building-a-toolkit/assets.html
@@ -10,7 +10,7 @@ section: Documentation
 
 > How to work with CSS and JS within Fabricator
 
-Fabricator comes with little opinion about how you should architect your Stylesheets and JavaScript. Each use case is different, so its up to you to define what works best.
+Fabricator comes with little opinion about how you should architect your Stylesheets and JavaScript. Each use case is different, so it's up to you to define what works best.
 
 Out of the box, you'll find a single `.scss` and `.js` file. These are the entry points for Sass compilation and Browserify respectively. It is recommended that you leverage the module importing features of each preprocessor to compile your toolkit down to a single `.css` and `.js` file. Practically speaking, you should be able to drop these two files into any application and have full access to your entire toolkit.
 


### PR DESCRIPTION
_Its_ was used as possessive, but needs to be _it's_

**Changed**

> Fabricator comes with little opinion about how you should architect your Stylesheets and JavaScript. 
> Each use case is different, so its up to you to define what works best.

**To**

> Fabricator comes with little opinion about how you should architect your Stylesheets and JavaScript. Each use case is different, so it's up to you to define what works best.
